### PR TITLE
types: use yasna for OIDs instead of simple_asn1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["cryptography", "parser-implementations"]
 license = "Apache-2.0"
 
 [dependencies]
-simple_asn1 = "0.1"
 byteorder = "1.2"
 digest = "0.7"
 failure = "0.1"
@@ -20,6 +19,7 @@ num = "0.1.40"
 ripemd160 = "0.7"
 sha-1 = "0.7"
 sha2 = "0.7"
+yasna = "0.1.3"
 
 [dependencies.nom]
 version = "^3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@
 //! [`Packet::to_bytes`]: enum.Packet.html#method.to_bytes
 //! [`Packet::from_bytes`]: enum.Packet.html#method.from_bytes
 //! [`SignaturePacket`]: struct.SignaturePacket.html
-#[macro_use]
-extern crate simple_asn1;
 extern crate byteorder;
 extern crate digest;
 #[macro_use]
@@ -32,6 +30,7 @@ extern crate num;
 extern crate ripemd160;
 extern crate sha1;
 extern crate sha2;
+extern crate yasna;
 
 mod packet;
 mod signature;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,6 @@
-use simple_asn1::OID;
 use digest::Digest;
 use failure::Error;
-use num::BigUint;
+use yasna::models::ObjectIdentifier;
 
 /// Type for public key algorithms supported by OpenPGP.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -102,15 +101,23 @@ macro_rules! hash {
 }
 
 impl HashAlgorithm {
-    pub fn asn1_oid(&self) -> Result<OID, Error> {
+    pub fn asn1_oid(&self) -> Result<ObjectIdentifier, Error> {
         let oid = match *self {
-            HashAlgorithm::Md5 => oid![1, 2, 840, 113549, 2, 5],
-            HashAlgorithm::Sha1 => oid![1, 3, 14, 3, 2, 26],
-            HashAlgorithm::Ripemd160 => oid![1, 3, 36, 3, 2, 1],
-            HashAlgorithm::Sha256 => oid![2, 16, 840, 1, 101, 3, 4, 2, 1],
-            HashAlgorithm::Sha384 => oid![2, 16, 840, 1, 101, 3, 4, 2, 2],
-            HashAlgorithm::Sha512 => oid![2, 16, 840, 1, 101, 3, 4, 2, 3],
-            HashAlgorithm::Sha224 => oid![2, 16, 840, 1, 101, 3, 4, 2, 4],
+            HashAlgorithm::Md5 => ObjectIdentifier::from_slice(&[1, 2, 840, 113_549, 2, 5]),
+            HashAlgorithm::Sha1 => ObjectIdentifier::from_slice(&[1, 3, 14, 3, 2, 26]),
+            HashAlgorithm::Ripemd160 => ObjectIdentifier::from_slice(&[1, 3, 36, 3, 2, 1]),
+            HashAlgorithm::Sha256 => {
+                ObjectIdentifier::from_slice(&[2, 16, 840, 1, 101, 3, 4, 2, 1])
+            }
+            HashAlgorithm::Sha384 => {
+                ObjectIdentifier::from_slice(&[2, 16, 840, 1, 101, 3, 4, 2, 2])
+            }
+            HashAlgorithm::Sha512 => {
+                ObjectIdentifier::from_slice(&[2, 16, 840, 1, 101, 3, 4, 2, 3])
+            }
+            HashAlgorithm::Sha224 => {
+                ObjectIdentifier::from_slice(&[2, 16, 840, 1, 101, 3, 4, 2, 4])
+            }
             HashAlgorithm::Unknown => bail!(AlgorithmError::HashAlgorithmError),
         };
 


### PR DESCRIPTION
yasna supports more operations and is more useful for things depending
on pretty-good.