### PR TITLE
Explicitly enable unstable library feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@
 //! [`Packet::to_bytes`]: enum.Packet.html#method.to_bytes
 //! [`Packet::from_bytes`]: enum.Packet.html#method.from_bytes
 //! [`SignaturePacket`]: struct.SignaturePacket.html
+
+#![feature(refcell_replace_swap)]
+
 extern crate byteorder;
 extern crate bzip2;
 extern crate digest;


### PR DESCRIPTION
rustc 1.23.0 currently bails with:

error: use of unstable library feature 'refcell_replace_swap' (see issue #43570)
   --> src/signature.rs:466:31
    |
466 |             self.payload_hash.replace(Some([hash[0], hash[1]]));
    |                               ^^^^^^^
    |
    = help: add #![feature(refcell_replace_swap)] to the crate attributes to enable

error: aborting due to previous error

error: Could not compile `pretty-good`.